### PR TITLE
ci: add prek and pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.9.26
+    hooks:
+      - id: uv-lock
+        stages: [pre-commit, post-checkout, post-merge, post-rewrite]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.13
+    hooks:
+      - id: ruff-check
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        args: [--check]
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          [
+            feat,
+            fix,
+            docs,
+            style,
+            refactor,
+            perf,
+            test,
+            build,
+            ci,
+            chore,
+            --optional-scopes,
+            --strict,
+          ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,11 @@ vaultuner = "vaultuner.cli:app"
 
 [dependency-groups]
 dev = [
+    "prek>=0.1.0",
     "pytest>=8.0.0",
 ]
 
 [build-system]
 requires = ["uv_build>=0.9.29,<0.10.0"]
 build-backend = "uv_build"
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
 from vaultuner.cli import (
@@ -29,7 +28,9 @@ class TestMarkDeleted:
         assert mark_deleted("project/name") == "_deleted_/project/name"
 
     def test_already_deleted(self):
-        assert mark_deleted("_deleted_/project/name") == "_deleted_/_deleted_/project/name"
+        assert (
+            mark_deleted("_deleted_/project/name") == "_deleted_/_deleted_/project/name"
+        )
 
 
 class TestUnmarkDeleted:
@@ -58,7 +59,9 @@ class TestConfigSet:
 class TestConfigShow:
     @patch("vaultuner.cli.get_keyring_value")
     def test_shows_configured(self, mock_get):
-        mock_get.side_effect = lambda key: "value" if key == "access_token" else "org-123"
+        mock_get.side_effect = (
+            lambda key: "value" if key == "access_token" else "org-123"
+        )
         result = runner.invoke(app, ["config", "show"])
         assert result.exit_code == 0
         assert "configured" in result.stdout
@@ -88,9 +91,7 @@ class TestListSecrets:
 
         secret = MagicMock(key="myproject/prod/api-key")
         client = MagicMock()
-        client.secrets().list.return_value = MagicMock(
-            data=MagicMock(data=[secret])
-        )
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=[secret]))
         mock_client.return_value = client
 
         result = runner.invoke(app, ["list"])
@@ -230,7 +231,9 @@ class TestDeleteSecret:
         client = MagicMock()
         mock_client.return_value = client
 
-        result = runner.invoke(app, ["delete", "myproject/api-key", "--force", "--permanent"])
+        result = runner.invoke(
+            app, ["delete", "myproject/api-key", "--force", "--permanent"]
+        )
         assert result.exit_code == 0
         assert "Permanently deleted" in result.stdout
         client.secrets().delete.assert_called_once()
@@ -254,7 +257,10 @@ class TestRestoreSecret:
     @patch("vaultuner.cli.get_settings")
     def test_restores(self, mock_settings, mock_client, mock_find):
         mock_settings.return_value = MagicMock(organization_id="org-123")
-        mock_find.return_value = {"id": "secret-id", "key": "_deleted_/myproject/api-key"}
+        mock_find.return_value = {
+            "id": "secret-id",
+            "key": "_deleted_/myproject/api-key",
+        }
         client = MagicMock()
         client.secrets().get.return_value = MagicMock(
             data=MagicMock(value="value", note=None, project_id="proj-id")
@@ -287,9 +293,7 @@ class TestProjects:
         project = MagicMock()
         project.name = "myproject"
         client = MagicMock()
-        client.projects().list.return_value = MagicMock(
-            data=MagicMock(data=[project])
-        )
+        client.projects().list.return_value = MagicMock(data=MagicMock(data=[project]))
         mock_client.return_value = client
 
         result = runner.invoke(app, ["projects"])
@@ -314,7 +318,9 @@ class TestExportCommand:
     def test_exports(self, mock_export, tmp_path):
         mock_export.return_value = (3, 1)
 
-        result = runner.invoke(app, ["export", "-p", "myproject", "-o", str(tmp_path / ".env")])
+        result = runner.invoke(
+            app, ["export", "-p", "myproject", "-o", str(tmp_path / ".env")]
+        )
         assert result.exit_code == 0
         assert "3 added" in result.output
         assert "1 already present" in result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,9 @@ class TestGetClient:
     @patch("vaultuner.client.BitwardenClient")
     @patch("vaultuner.client.client_settings_from_dict")
     @patch("vaultuner.client.get_settings")
-    def test_creates_authenticated_client(self, mock_settings, mock_client_settings, mock_client_class):
+    def test_creates_authenticated_client(
+        self, mock_settings, mock_client_settings, mock_client_class
+    ):
         from vaultuner.client import get_client
 
         settings = MagicMock()
@@ -40,9 +42,7 @@ class TestGetOrCreateProject:
         project.name = "myproject"
 
         client = MagicMock()
-        client.projects().list.return_value = MagicMock(
-            data=MagicMock(data=[project])
-        )
+        client.projects().list.return_value = MagicMock(data=MagicMock(data=[project]))
 
         result = get_or_create_project(client, "myproject")
         assert result == "project-id-123"
@@ -91,9 +91,7 @@ class TestFindSecretByKey:
         secret.key = "myproject/api-key"
 
         client = MagicMock()
-        client.secrets().list.return_value = MagicMock(
-            data=MagicMock(data=[secret])
-        )
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=[secret]))
 
         result = find_secret_by_key(client, "myproject/api-key")
         assert result == {"id": "secret-id-123", "key": "myproject/api-key"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,8 @@
 # ABOUTME: Tests for the config module.
 # ABOUTME: Tests keyring operations and settings loading.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 
 from vaultuner.config import (
     SERVICE_NAME,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,10 +1,8 @@
 # ABOUTME: Tests for the export module.
 # ABOUTME: Tests env file parsing, variable naming, and secret export.
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from vaultuner.export import (
     export_secrets,
@@ -182,12 +180,8 @@ class TestExportSecrets:
         secret = MagicMock(id="1", key="myproject/api-key")
 
         client = MagicMock()
-        client.secrets().list.return_value = MagicMock(
-            data=MagicMock(data=[secret])
-        )
-        client.secrets().get.return_value = MagicMock(
-            data=MagicMock(value="new-value")
-        )
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=[secret]))
+        client.secrets().get.return_value = MagicMock(data=MagicMock(value="new-value"))
         mock_client.return_value = client
 
         output = tmp_path / ".env"
@@ -209,12 +203,8 @@ class TestExportSecrets:
         secret = MagicMock(id="1", key="myproject/new-key")
 
         client = MagicMock()
-        client.secrets().list.return_value = MagicMock(
-            data=MagicMock(data=[secret])
-        )
-        client.secrets().get.return_value = MagicMock(
-            data=MagicMock(value="new-value")
-        )
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=[secret]))
+        client.secrets().get.return_value = MagicMock(data=MagicMock(value="new-value"))
         mock_client.return_value = client
 
         output = tmp_path / ".env"

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +211,48 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prek"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/62/4b91c8a343e21fcefabc569a91d08cf8756c554332521af78294acef7c27/prek-0.3.1.tar.gz", hash = "sha256:45abc4ffd3cb2d39c478f47e92e88f050e5a4b7a20915d78e54b1a3d3619ebe4", size = 323141, upload-time = "2026-01-31T13:25:58.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/c1/e0e545048e4190245fb4ae375d67684108518f3c69b67b81d62e1cd855c6/prek-0.3.1-py3-none-linux_armv6l.whl", hash = "sha256:1f77d0845cc63cad9c447f7f7d554c1ad188d07dbe02741823d20d58c7312eaf", size = 4285460, upload-time = "2026-01-31T13:25:42.066Z" },
+    { url = "https://files.pythonhosted.org/packages/10/fe/7636d10e2dafdf2a4a927c989f32ce3f08e99d62ebad7563f0272e74b7f4/prek-0.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e21142300d139e8c7f3970dd8aa66391cb43cd17c0c4ee65ff1af48856bb6a4b", size = 4287085, upload-time = "2026-01-31T13:25:40.193Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/7f/62ed57340071e04c02057d64276ec3986baca3ad4759523e2f433dc9be55/prek-0.3.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c09391de7d1994f9402c46cb31671800ea309b1668d839614965706206da3655", size = 3936188, upload-time = "2026-01-31T13:25:47.314Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/17/cb24f462c255f76d130ca110f4fcec09b041c3c770e43960cc3fc9dcc9ce/prek-0.3.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a0b0a012ef6ef28dee019cf81a95c5759b2c03287c32c1f2adcb5f5fb097138e", size = 4275214, upload-time = "2026-01-31T13:25:38.053Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/85/db155b59d73cf972c8467e4d95def635f9976d5fcbcc790a4bbe9d2e049a/prek-0.3.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4a0e40785d39b8feae0d7ecf5534789811a2614114ab47f4e344a2ebd75ac10", size = 4197982, upload-time = "2026-01-31T13:25:50.034Z" },
+    { url = "https://files.pythonhosted.org/packages/06/cf/d35c32436692928a9ca53eed3334e30148a60f0faa33c42e8d11b6028fa6/prek-0.3.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ac5c2f5e377e3cc5a5ea191deb8255a5823fbaa01b424417fe18ff12c7c800f3", size = 4458572, upload-time = "2026-01-31T13:25:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c0/eb36fecb21fe30baa72fb87ccf3a791c32932786c287f95f8972402e9245/prek-0.3.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fe70e97f4dfca57ce142caecd77b90a435abd1c855f9e96041078415d80e89a", size = 4999230, upload-time = "2026-01-31T13:25:44.055Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f3/ad1a25ea16320e6acd1fedd6bd96a0d22526f5132d9b5adc045996ccca4c/prek-0.3.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b28e921d893771bdd7533cd94d46a10e0cf2855c5e6bf6809b598b5e45baa73", size = 4510376, upload-time = "2026-01-31T13:25:48.563Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/91afdd24be808ccf3b9119f4cf2bd6d02e30683143a62a08f432a3435861/prek-0.3.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:555610a53c4541976f4fe8602177ecd7a86a931dcb90a89e5826cfc4a6c8f2cb", size = 4273229, upload-time = "2026-01-31T13:25:56.362Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bb/636c77c5c9fc5eadcc2af975a95b48eeeff2dc833021e222b0e9479b9b47/prek-0.3.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:663a15a31b705db5d01a1c9eb28c6ea417628e6cb68de2dc7b3016ca2f959a99", size = 4301166, upload-time = "2026-01-31T13:25:36.281Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/cf/c928a36173e71b21b252943404a5b3d1ddc1f08c9e0f1d7282a2c62c7325/prek-0.3.1-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:1d03fb5fa37177dc37ccbe474252473adcbde63287a63e9fa3d5745470f95bd8", size = 4188473, upload-time = "2026-01-31T13:25:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/98/4c/af8f6a40cb094e88225514b89e8ae05ac69fc479d6b500e4b984f9ef8ae3/prek-0.3.1-py3-none-musllinux_1_1_i686.whl", hash = "sha256:3e20a5b704c06944dca9555a39f1de3622edc8ed2becaf8b3564925d1b7c1c0d", size = 4342239, upload-time = "2026-01-31T13:25:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ba/6b0f725c0cf96182ab9622b4d122a01f04de9b2b6e4a6516874390218510/prek-0.3.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6889acf0c9b0dd7b9cd3510ec36af10a739826d2b9de1e2d021ae6a9f130959a", size = 4618674, upload-time = "2026-01-31T13:25:59.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/49/caa320893640c9e72ed3d3e2bab7959faba54cefeea09be18c33d5f75baf/prek-0.3.1-py3-none-win32.whl", hash = "sha256:cc62a4bff79ed835d448098f0667c1a91915cec9cfac6c6246b675f0da46eded", size = 3928699, upload-time = "2026-01-31T13:25:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/15907abe245ae9a120abcebb0c50c6d456ba719eb640f7c57e4f5b2f00e3/prek-0.3.1-py3-none-win_amd64.whl", hash = "sha256:3515140def20bab85e53585b0beb90d894ff2915d2fdb4451b6a4588e16516d8", size = 4296106, upload-time = "2026-01-31T13:25:45.606Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/5e/9b994b5de36d6aa5caaf09a018d8fe4820db46e4da577c2fd7a1e176b56c/prek-0.3.1-py3-none-win_arm64.whl", hash = "sha256:cfa58365eb36753cff684dc3b00196c1163bb135fe72c6a1c6ebb1a179f5dbdf", size = 4021714, upload-time = "2026-01-31T13:25:34.993Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -275,6 +326,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -409,6 +476,12 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "prek" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bitwarden-sdk", specifier = ">=1.0.0" },
@@ -417,4 +490,10 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "typer", specifier = ">=0.21.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "prek", specifier = ">=0.1.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
 ]


### PR DESCRIPTION
## Summary
- Add prek as dev dependency for git hooks
- Add .pre-commit-config.yaml with ruff, uv-lock, taplo, and conventional commits
- Fix linting issues in tests

## Test plan
- [x] Tests pass (74 passed)
- [ ] Verify prek hooks work locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)