### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/vaultuner/cli.py
+++ b/src/vaultuner/cli.py
@@ -1,8 +1,9 @@
 # ABOUTME: Typer CLI for Bitwarden Secrets Manager.
 # ABOUTME: Commands for listing, getting, setting, and deleting secrets.
 
+from importlib.metadata import version
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 import typer
 from rich.console import Console
@@ -19,12 +20,31 @@ from vaultuner.models import SecretPath
 
 DELETED_PREFIX = "_deleted_/"
 
+__version__ = version("vaultuner")
+
+
+def version_callback(value: bool) -> None:
+    if value:
+        print(f"vaultuner {__version__}")
+        raise typer.Exit()
+
+
 app = typer.Typer(
-    help="Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET naming.",
+    help=f"Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET naming. (v{__version__})",
     no_args_is_help=True,
 )
 config_app = typer.Typer(help="Manage vaultuner credentials stored in system keychain.")
 app.add_typer(config_app, name="config")
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        bool, typer.Option("--version", "-V", callback=version_callback, is_eager=True)
+    ] = False,
+) -> None:
+    """Bitwarden Secrets Manager CLI."""
+
 
 console = Console()
 err_console = Console(stderr=True)

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "vaultuner"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "bitwarden-sdk" },


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` flag to show version
- Show version in help text header

```
$ vaultuner --version
vaultuner 0.1.1

$ vaultuner --help
Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET naming. (v0.1.1)
```

## Test plan
- [x] 74 tests pass
- [x] `vaultuner --version` works
- [x] Version shown in help

🤖 Generated with [Claude Code](https://claude.com/claude-code)