### PR TITLE
Prepare for release: license, readme, docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ wheels/
 # Environment files
 .env
 .claude/
+
+# MkDocs
+site/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 David Poblador
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,96 +1,89 @@
 # vaultuner
 
-Bitwarden Secrets Manager CLI with `PROJECT/[ENV/]SECRET` naming convention.
+[![PyPI version](https://img.shields.io/github/v/release/alltuner/vaultuner)](https://github.com/alltuner/vaultuner/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 
-## Requirements
+**A developer-friendly CLI for Bitwarden Secrets Manager** with intuitive `PROJECT/[ENV/]SECRET` naming.
 
-- Python 3.12
+Stop managing cryptic secret IDs. Vaultuner organizes your secrets the way you think about them: by project and environment.
 
-## Installation
+## Features
+
+- **Intuitive naming**: `myapp/prod/db-password` instead of UUIDs
+- **Project organization**: Group secrets by project automatically
+- **Environment support**: Separate dev, staging, and prod secrets
+- **Soft delete**: Recover accidentally deleted secrets
+- **Export/Import**: Sync with `.env` files for local development
+- **Secure storage**: Credentials stored in macOS Keychain
+
+## Quick Start
+
+### Installation
 
 ```bash
 uv tool install git+https://github.com/alltuner/vaultuner --python 3.12
 ```
 
-## Configuration
-
-Store your Bitwarden Secrets Manager credentials:
+### Configuration
 
 ```bash
 vaultuner config set access-token <your-access-token>
 vaultuner config set organization-id <your-org-id>
 ```
 
-Credentials are stored securely in your system keychain.
+Get your access token from the [Bitwarden Secrets Manager](https://vault.bitwarden.com/).
 
-## Usage
-
-### List secrets
+### Basic Usage
 
 ```bash
+# Create a secret
+vaultuner set myapp/api-key "sk-abc123"
+
+# Get a secret
+vaultuner get myapp/api-key
+
+# List all secrets
 vaultuner list
-vaultuner list -p myproject
-vaultuner list -p myproject -e prod
+
+# Export to .env for local development
+vaultuner export -p myapp -o .env
 ```
 
-### Get a secret
+## Documentation
 
-```bash
-vaultuner get myproject/api-key
-vaultuner get myproject/prod/db-password
-vaultuner get myproject/api-key --value  # value only
-```
+Full documentation available at [alltuner.github.io/vaultuner](https://alltuner.github.io/vaultuner).
 
-### Set a secret
+## Commands
 
-```bash
-vaultuner set myproject/api-key "secret-value"
-vaultuner set myproject/prod/db-password "password" --note "Production DB"
-```
+| Command | Description |
+|---------|-------------|
+| `list` | List secrets (filter by project/env) |
+| `get` | Retrieve a secret value |
+| `set` | Create or update a secret |
+| `delete` | Soft-delete a secret |
+| `restore` | Restore a deleted secret |
+| `export` | Export secrets to .env file |
+| `import` | Import secrets from .env file |
+| `projects` | List all projects |
+| `config` | Manage credentials |
 
-### Delete a secret
-
-```bash
-vaultuner delete myproject/api-key           # soft delete
-vaultuner delete myproject/api-key --permanent  # hard delete
-```
-
-### Restore a deleted secret
-
-```bash
-vaultuner restore myproject/api-key
-```
-
-### Export to .env file
-
-```bash
-vaultuner export                    # uses current directory name as project
-vaultuner export -p myproject       # specify project
-vaultuner export -p myproject -e prod  # filter by environment
-vaultuner export -o secrets.env     # custom output file
-```
-
-### Import from .env file
-
-```bash
-vaultuner import                    # interactive import from .env
-vaultuner import -p myproject       # specify project
-vaultuner import -e prod            # import to specific environment
-vaultuner import -i secrets.env     # custom input file
-vaultuner import -y                 # import all without prompting
-```
-
-Existing secrets are skipped automatically.
-
-### List projects
-
-```bash
-vaultuner projects
-```
-
-## Secret naming convention
+## Secret Naming Convention
 
 Secrets follow the pattern `PROJECT/[ENV/]SECRET`:
 
-- `myapp/api-key` - project-level secret (no environment)
-- `myapp/prod/db-password` - environment-specific secret
+```
+myapp/api-key              # Project-level secret
+myapp/prod/db-password     # Environment-specific secret
+myapp/dev/db-password      # Different value per environment
+```
+
+## Requirements
+
+- Python 3.12
+- macOS (for Keychain support)
+- Bitwarden Secrets Manager account
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -1,0 +1,72 @@
+# config
+
+Manage vaultuner credentials.
+
+## Usage
+
+```bash
+vaultuner config COMMAND [OPTIONS]
+```
+
+## Commands
+
+### config set
+
+Store a credential in the system keychain.
+
+```bash
+vaultuner config set KEY VALUE
+```
+
+**Keys:**
+
+- `access-token` - Your Bitwarden access token
+- `organization-id` - Your Bitwarden organization ID
+
+**Examples:**
+
+```bash
+vaultuner config set access-token "0.abc123..."
+vaultuner config set organization-id "550e8400-e29b-..."
+```
+
+### config show
+
+Show current configuration status.
+
+```bash
+vaultuner config show
+```
+
+**Output:**
+
+```
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Setting          ┃ Status       ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ access-token     │ configured   │
+│ organization-id  │ configured   │
+└──────────────────┴──────────────┘
+```
+
+### config delete
+
+Remove a credential from the system keychain.
+
+```bash
+vaultuner config delete KEY
+```
+
+**Examples:**
+
+```bash
+vaultuner config delete access-token
+vaultuner config delete organization-id
+```
+
+## Storage
+
+Credentials are stored securely in the macOS Keychain under the service name `vaultuner`.
+
+!!! note
+    Keychain storage is only available on macOS. On other platforms, use environment variables `BWS_ACCESS_TOKEN` and `BWS_ORGANIZATION_ID`.

--- a/docs/commands/delete.md
+++ b/docs/commands/delete.md
@@ -1,0 +1,52 @@
+# delete
+
+Delete a secret.
+
+## Usage
+
+```bash
+vaultuner delete PATH [OPTIONS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Secret path: `PROJECT/[ENV/]NAME` |
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--force` | `-f` | Skip confirmation prompt |
+| `--permanent` | | Permanently delete (cannot be restored) |
+
+## Examples
+
+```bash
+# Soft delete (can be restored)
+vaultuner delete myapp/api-key
+
+# Skip confirmation
+vaultuner delete myapp/api-key -f
+
+# Permanent delete
+vaultuner delete myapp/api-key --permanent
+```
+
+## Soft Delete vs Permanent Delete
+
+By default, `delete` performs a **soft delete**:
+
+- The secret is renamed with a `_deleted_/` prefix
+- It's hidden from normal `list` output
+- It can be recovered with `vaultuner restore`
+
+With `--permanent`, the secret is **permanently removed** from Bitwarden and cannot be recovered.
+
+!!! warning
+    Permanent deletes cannot be undone. Use with caution.
+
+## See Also
+
+- [restore](restore.md) - Restore a soft-deleted secret

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -1,0 +1,61 @@
+# export
+
+Export secrets to a `.env` file.
+
+## Usage
+
+```bash
+vaultuner export [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--project` | `-p` | Project name (defaults to current directory name) |
+| `--env` | `-e` | Filter by environment |
+| `--output` | `-o` | Output file path (default: `.env`) |
+
+## Examples
+
+```bash
+# Export using current directory as project name
+vaultuner export
+
+# Export specific project
+vaultuner export -p myapp
+
+# Export only production secrets
+vaultuner export -p myapp -e prod
+
+# Custom output file
+vaultuner export -p myapp -o secrets.env
+```
+
+## Output Format
+
+Secrets are exported in standard `.env` format:
+
+```bash
+API_KEY="sk-test-abc123"
+DB_PASSWORD="super-secret"
+```
+
+### Name Conversion
+
+Secret names are converted to environment variable format:
+
+| Secret Name | Environment Variable |
+|-------------|---------------------|
+| `api-key` | `API_KEY` |
+| `db-password` | `DB_PASSWORD` |
+
+## Behavior
+
+- If the output file exists, new secrets are **appended**
+- Existing variables in the file are **not overwritten**
+- Skipped variables are noted in comments
+
+## See Also
+
+- [import](import.md) - Import secrets from .env file

--- a/docs/commands/get.md
+++ b/docs/commands/get.md
@@ -1,0 +1,53 @@
+# get
+
+Retrieve a secret by its path.
+
+## Usage
+
+```bash
+vaultuner get PATH [OPTIONS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Secret path: `PROJECT/[ENV/]NAME` |
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--value` | `-v` | Print only the secret value |
+
+## Examples
+
+```bash
+# Get a project-level secret
+vaultuner get myapp/api-key
+
+# Get an environment-specific secret
+vaultuner get myapp/prod/db-password
+
+# Get just the value (for scripts)
+vaultuner get myapp/api-key -v
+
+# Use in shell scripts
+DB_PASS=$(vaultuner get myapp/prod/db-password -v)
+```
+
+## Output
+
+Without `--value`:
+
+```
+Path   myapp/api-key
+Value  sk-test-abc123
+Note   API key for external service
+```
+
+With `--value`:
+
+```
+sk-test-abc123
+```

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -1,0 +1,68 @@
+# import
+
+Import secrets from a `.env` file.
+
+## Usage
+
+```bash
+vaultuner import [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--project` | `-p` | Project name (defaults to current directory name) |
+| `--env` | `-e` | Environment for imported secrets |
+| `--input` | `-i` | Input file path (default: `.env`) |
+| `--yes` | `-y` | Import all without prompting |
+
+## Examples
+
+```bash
+# Interactive import from .env
+vaultuner import
+
+# Import to specific project
+vaultuner import -p myapp
+
+# Import as production secrets
+vaultuner import -p myapp -e prod
+
+# Custom input file
+vaultuner import -p myapp -i secrets.env
+
+# Import all without confirmation
+vaultuner import -p myapp -y
+```
+
+## Interactive Mode
+
+By default, import runs interactively:
+
+```
+API_KEY = sk-test-abc...
+  → myapp/api-key
+Store this secret? [Y/n]:
+```
+
+Use `-y` to skip confirmations and import all secrets.
+
+## Name Conversion
+
+Environment variable names are converted to secret names:
+
+| Environment Variable | Secret Name |
+|---------------------|-------------|
+| `API_KEY` | `api-key` |
+| `DB_PASSWORD` | `db-password` |
+
+## Behavior
+
+- Existing secrets are **skipped** (not overwritten)
+- Blank lines and comments are ignored
+- Quoted values have quotes stripped
+
+## See Also
+
+- [export](export.md) - Export secrets to .env file

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,0 +1,42 @@
+# list
+
+List secrets in your organization.
+
+## Usage
+
+```bash
+vaultuner list [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--project` | `-p` | Filter by project name |
+| `--env` | `-e` | Filter by environment |
+| `--deleted` | `-d` | Show deleted secrets |
+
+## Examples
+
+```bash
+# List all secrets
+vaultuner list
+
+# List secrets for a project
+vaultuner list -p myapp
+
+# List production secrets
+vaultuner list -p myapp -e prod
+
+# Include deleted secrets
+vaultuner list -d
+```
+
+## Output
+
+Displays a table with columns:
+
+- **Project**: The project name
+- **Env**: The environment (or `-` if none)
+- **Name**: The secret name
+- **Status**: (only with `--deleted`) Shows if secret is active or deleted

--- a/docs/commands/projects.md
+++ b/docs/commands/projects.md
@@ -1,0 +1,31 @@
+# projects
+
+List all projects in your organization.
+
+## Usage
+
+```bash
+vaultuner projects
+```
+
+## Examples
+
+```bash
+vaultuner projects
+```
+
+## Output
+
+```
+┏━━━━━━━━━━━━┓
+┃ Project    ┃
+┡━━━━━━━━━━━━┩
+│ myapp      │
+│ backend    │
+│ frontend   │
+└────────────┘
+```
+
+## Notes
+
+Projects are created automatically when you create secrets. This command lists all projects that exist in your Bitwarden organization.

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -1,0 +1,36 @@
+# restore
+
+Restore a soft-deleted secret.
+
+## Usage
+
+```bash
+vaultuner restore PATH
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Original secret path: `PROJECT/[ENV/]NAME` |
+
+## Examples
+
+```bash
+# Restore a deleted secret
+vaultuner restore myapp/api-key
+
+# Check what's deleted first
+vaultuner list -d
+```
+
+## Notes
+
+- Only works for soft-deleted secrets (deleted without `--permanent`)
+- Use `vaultuner list -d` to see deleted secrets
+- The secret is restored to its original path
+
+## See Also
+
+- [delete](delete.md) - Delete a secret
+- [Soft Delete concept](../concepts/soft-delete.md)

--- a/docs/commands/set.md
+++ b/docs/commands/set.md
@@ -1,0 +1,44 @@
+# set
+
+Create or update a secret.
+
+## Usage
+
+```bash
+vaultuner set PATH VALUE [OPTIONS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Secret path: `PROJECT/[ENV/]NAME` |
+| `VALUE` | The secret value |
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--note` | `-n` | Optional note/description |
+
+## Examples
+
+```bash
+# Create a project-level secret
+vaultuner set myapp/api-key "sk-test-abc123"
+
+# Create an environment-specific secret
+vaultuner set myapp/prod/db-password "super-secret"
+
+# Add a note
+vaultuner set myapp/api-key "sk-test-abc123" -n "Stripe test key"
+
+# Update an existing secret
+vaultuner set myapp/api-key "new-value"
+```
+
+## Behavior
+
+- If the secret doesn't exist, it's created
+- If the secret exists, it's updated
+- The secret is automatically associated with a project in Bitwarden

--- a/docs/concepts/naming.md
+++ b/docs/concepts/naming.md
@@ -1,0 +1,76 @@
+# Naming Convention
+
+Vaultuner uses a hierarchical naming system: `PROJECT/[ENV/]SECRET`
+
+## Path Format
+
+### Two-Part Path: `PROJECT/SECRET`
+
+For secrets that don't vary by environment:
+
+```bash
+myapp/api-key
+myapp/encryption-key
+backend/jwt-secret
+```
+
+### Three-Part Path: `PROJECT/ENV/SECRET`
+
+For environment-specific secrets:
+
+```bash
+myapp/dev/db-password
+myapp/staging/db-password
+myapp/prod/db-password
+```
+
+## Naming Best Practices
+
+### Project Names
+
+- Use lowercase
+- Match your repository or service name
+- Examples: `myapp`, `backend-api`, `payment-service`
+
+### Environment Names
+
+Common patterns:
+
+- `dev`, `staging`, `prod`
+- `development`, `test`, `production`
+- `local`, `ci`, `preview`
+
+### Secret Names
+
+- Use lowercase with dashes
+- Be descriptive but concise
+- Examples: `api-key`, `db-password`, `stripe-secret-key`
+
+## Examples
+
+```bash
+# Web application
+webapp/stripe-api-key           # Shared across environments
+webapp/dev/database-url         # Development database
+webapp/prod/database-url        # Production database
+
+# Microservice
+user-service/jwt-secret
+user-service/prod/redis-url
+
+# Infrastructure
+infra/aws-access-key
+infra/prod/cloudflare-api-token
+```
+
+## Name Conversion
+
+When exporting to `.env`, names are converted:
+
+| Secret Name | Environment Variable |
+|-------------|---------------------|
+| `api-key` | `API_KEY` |
+| `db-password` | `DB_PASSWORD` |
+| `stripe-secret-key` | `STRIPE_SECRET_KEY` |
+
+When importing from `.env`, the reverse conversion happens.

--- a/docs/concepts/soft-delete.md
+++ b/docs/concepts/soft-delete.md
@@ -1,0 +1,66 @@
+# Soft Delete
+
+Vaultuner implements soft delete to protect against accidental data loss.
+
+## How It Works
+
+When you delete a secret without `--permanent`:
+
+1. The secret is **renamed** with a `_deleted_/` prefix
+2. It's **hidden** from normal `list` output
+3. It can be **restored** at any time
+
+```bash
+# Original secret
+myapp/api-key
+
+# After soft delete
+_deleted_/myapp/api-key
+```
+
+## Viewing Deleted Secrets
+
+```bash
+vaultuner list -d
+```
+
+This shows both active and deleted secrets with their status.
+
+## Restoring a Secret
+
+```bash
+vaultuner restore myapp/api-key
+```
+
+The secret is renamed back to its original path.
+
+## Permanent Delete
+
+To bypass soft delete and permanently remove a secret:
+
+```bash
+vaultuner delete myapp/api-key --permanent
+```
+
+!!! warning
+    Permanent deletes cannot be undone. The secret is removed from Bitwarden entirely.
+
+## Why Soft Delete?
+
+Soft delete provides a safety net:
+
+- **Accidental deletion**: Recover secrets deleted by mistake
+- **Audit trail**: See what was deleted and when
+- **No downtime**: Restore quickly without recreating secrets
+
+## Cleaning Up
+
+To permanently remove all deleted secrets, delete them again with `--permanent`:
+
+```bash
+# List deleted secrets
+vaultuner list -d
+
+# Permanently remove specific ones
+vaultuner delete myapp/old-key --permanent
+```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,54 @@
+# Configuration
+
+Vaultuner needs two pieces of information to connect to Bitwarden Secrets Manager:
+
+1. **Access Token**: Authenticates your CLI
+2. **Organization ID**: Identifies your Bitwarden organization
+
+## Getting Your Credentials
+
+### Access Token
+
+1. Log in to [Bitwarden Vault](https://vault.bitwarden.com/)
+2. Go to **Secrets Manager** > **Machine Accounts**
+3. Create a new machine account or select an existing one
+4. Generate an access token
+
+### Organization ID
+
+1. In Bitwarden Vault, go to **Organizations**
+2. Click on your organization
+3. Find the **Organization ID** in the settings
+
+## Storing Credentials
+
+Vaultuner stores credentials securely in your macOS Keychain:
+
+```bash
+vaultuner config set access-token <your-access-token>
+vaultuner config set organization-id <your-org-id>
+```
+
+## Verify Configuration
+
+```bash
+vaultuner config show
+```
+
+You should see both settings marked as configured.
+
+## Alternative: Environment Variables
+
+If you prefer not to use the Keychain (or on non-macOS systems), set environment variables:
+
+```bash
+export BWS_ACCESS_TOKEN="your-access-token"
+export BWS_ORGANIZATION_ID="your-org-id"
+```
+
+!!! note
+    Keychain storage is only available on macOS. On other platforms, use environment variables.
+
+## Next Steps
+
+Once configured, try the [quick start guide](quickstart.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,33 @@
+# Installation
+
+## Requirements
+
+- Python 3.12
+- macOS (for Keychain credential storage)
+- A [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/) account
+
+## Install with uv (Recommended)
+
+The fastest way to install vaultuner is using [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install git+https://github.com/alltuner/vaultuner --python 3.12
+```
+
+This installs vaultuner as a standalone tool with its own isolated environment.
+
+## Install with pip
+
+```bash
+pip install git+https://github.com/alltuner/vaultuner
+```
+
+## Verify Installation
+
+```bash
+vaultuner --version
+```
+
+## Next Steps
+
+After installation, [configure your credentials](configuration.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,88 @@
+# Quick Start
+
+This guide walks you through common vaultuner workflows.
+
+## Create Your First Secret
+
+```bash
+vaultuner set myapp/api-key "sk-test-abc123"
+```
+
+This creates a secret named `api-key` in the `myapp` project.
+
+## Retrieve a Secret
+
+```bash
+# Full output with metadata
+vaultuner get myapp/api-key
+
+# Just the value (useful for scripts)
+vaultuner get myapp/api-key --value
+```
+
+## Environment-Specific Secrets
+
+Use the three-part path for environment-specific secrets:
+
+```bash
+# Development
+vaultuner set myapp/dev/db-password "dev-password"
+
+# Production
+vaultuner set myapp/prod/db-password "prod-password"
+```
+
+## List Secrets
+
+```bash
+# All secrets
+vaultuner list
+
+# Filter by project
+vaultuner list -p myapp
+
+# Filter by project and environment
+vaultuner list -p myapp -e prod
+```
+
+## Export to .env
+
+Export secrets for local development:
+
+```bash
+# Export all secrets for a project
+vaultuner export -p myapp
+
+# Export only production secrets
+vaultuner export -p myapp -e prod -o .env.prod
+```
+
+## Import from .env
+
+Import secrets from an existing .env file:
+
+```bash
+# Interactive import (confirms each secret)
+vaultuner import -p myapp -i .env
+
+# Import all without prompting
+vaultuner import -p myapp -i .env -y
+```
+
+## Delete and Restore
+
+```bash
+# Soft delete (can be restored)
+vaultuner delete myapp/api-key
+
+# Restore a deleted secret
+vaultuner restore myapp/api-key
+
+# Permanent delete
+vaultuner delete myapp/api-key --permanent
+```
+
+## Next Steps
+
+- Learn about the [naming convention](../concepts/naming.md)
+- Explore all [commands](../commands/list.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# Vaultuner
+
+**A developer-friendly CLI for Bitwarden Secrets Manager** with intuitive `PROJECT/[ENV/]SECRET` naming.
+
+Stop managing cryptic secret IDs. Vaultuner organizes your secrets the way you think about them: by project and environment.
+
+## Why Vaultuner?
+
+Bitwarden Secrets Manager is powerful, but its default CLI uses UUIDs to reference secrets. Vaultuner gives you a human-friendly naming system:
+
+```bash
+# Instead of this:
+bws secret get 550e8400-e29b-41d4-a716-446655440000
+
+# You get this:
+vaultuner get myapp/prod/db-password
+```
+
+## Features
+
+- **Intuitive naming**: `myapp/prod/db-password` instead of UUIDs
+- **Project organization**: Group secrets by project automatically
+- **Environment support**: Separate dev, staging, and prod secrets
+- **Soft delete**: Recover accidentally deleted secrets
+- **Export/Import**: Sync with `.env` files for local development
+- **Secure storage**: Credentials stored in macOS Keychain
+
+## Quick Example
+
+```bash
+# Store a secret
+vaultuner set myapp/prod/api-key "sk-live-abc123"
+
+# Retrieve it
+vaultuner get myapp/prod/api-key --value
+
+# Export all prod secrets to .env
+vaultuner export -p myapp -e prod -o .env
+```
+
+## Getting Started
+
+1. [Install vaultuner](getting-started/installation.md)
+2. [Configure your credentials](getting-started/configuration.md)
+3. [Try the quick start guide](getting-started/quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: Vaultuner
+site_description: A developer-friendly CLI for Bitwarden Secrets Manager
+site_url: https://alltuner.github.io/vaultuner
+repo_url: https://github.com/alltuner/vaultuner
+repo_name: alltuner/vaultuner
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Configuration: getting-started/configuration.md
+      - Quick Start: getting-started/quickstart.md
+  - Commands:
+      - list: commands/list.md
+      - get: commands/get.md
+      - set: commands/set.md
+      - delete: commands/delete.md
+      - restore: commands/restore.md
+      - export: commands/export.md
+      - import: commands/import.md
+      - projects: commands/projects.md
+      - config: commands/config.md
+  - Concepts:
+      - Naming Convention: concepts/naming.md
+      - Soft Delete: concepts/soft-delete.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/alltuner/vaultuner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,26 +3,36 @@ name = "vaultuner"
 version = "0.1.3"
 description = "Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET naming"
 readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "David Poblador" }]
+keywords = ["bitwarden", "secrets", "cli", "secrets-manager", "devops"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Security",
+  "Topic :: Utilities",
+]
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "bitwarden-sdk>=1.0.0",
-    "keyring>=25.7.0",
-    "pydantic>=2.12.5",
-    "pydantic-settings>=2.12.0",
-    "rich>=14.3.2",
-    "typer>=0.21.1",
+  "bitwarden-sdk>=1.0.0",
+  "keyring>=25.7.0",
+  "pydantic>=2.12.5",
+  "pydantic-settings>=2.12.0",
+  "rich>=14.3.2",
+  "typer>=0.21.1",
 ]
 
 [project.scripts]
 vaultuner = "vaultuner.cli:app"
 
 [dependency-groups]
-dev = [
-    "prek>=0.1.0",
-    "pytest>=8.0.0",
-]
+dev = ["prek>=0.1.0", "pytest>=8.0.0"]
+docs = ["mkdocs>=1.6.0", "mkdocs-material>=9.5.0"]
 
 [build-system]
 requires = ["uv_build>=0.9.29,<0.10.0"]
 build-backend = "uv_build"
-

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,27 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+]
+
+[[package]]
 name = "bitwarden-sdk"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -25,6 +46,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/47/f849a9402b931f56f5476f603b21cda92e90323fb73ad2546014e3b8eb52/bitwarden_sdk-1.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9a6aada6f421f5fc26f4e9bbc7f3e538439cb388794021214e49ce7578a8d345", size = 2537437, upload-time = "2024-09-30T13:30:55.475Z" },
     { url = "https://files.pythonhosted.org/packages/dc/3a/42f4ae601947e39a48cb3e23e672fe467bb9ed22ebe869778860cece8c4a/bitwarden_sdk-1.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2fae1101b527ffdceed2f817d16d20076a5949df9fc64184053f09ff79f035f3", size = 2616881, upload-time = "2024-09-30T13:30:57.538Z" },
     { url = "https://files.pythonhosted.org/packages/28/b3/43fda8bac7e21e431088270ad2e5d0deaa4847315f1687c9b8eacb56300f/bitwarden_sdk-1.0.0-cp312-none-win_amd64.whl", hash = "sha256:7198c80a1cb87d28f2f134db3296b3e34255c8ba4b9863a5c9a2dca3c2ce6803", size = 2235663, upload-time = "2024-09-30T13:30:58.748Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
 ]
 
 [[package]]
@@ -43,6 +73,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
 [[package]]
@@ -113,6 +168,27 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +240,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -181,6 +269,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/b1/af95bcae8549f1f3fd70faacb29075826a0d689a27f232e8cee315efa053/markdown-3.10.1.tar.gz", hash = "sha256:1c19c10bd5c14ac948c53d0d762a04e2fa35a6d58a6b7b1e6bfcbe6fefc0001a", size = 365402, upload-time = "2026-01-21T18:09:28.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/1b/6ef961f543593969d25b2afe57a3564200280528caa9bd1082eecdd7b3bc/markdown-3.10.1-py3-none-any.whl", hash = "sha256:867d788939fe33e4b736426f5b9f651ad0c0ae0ecf89df0ca5d1176c70812fe3", size = 107684, upload-time = "2026-01-21T18:09:27.203Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -193,12 +290,109 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -217,6 +411,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -329,6 +550,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -381,6 +615,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -464,8 +743,17 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
 name = "vaultuner"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "bitwarden-sdk" },
@@ -480,6 +768,10 @@ dependencies = [
 dev = [
     { name = "prek" },
     { name = "pytest" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
 ]
 
 [package.metadata]
@@ -496,4 +788,29 @@ requires-dist = [
 dev = [
     { name = "prek", specifier = ">=0.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Summary
Prepares vaultuner for public release with:

- **MIT License** - Added LICENSE file
- **Marketing README** - Rewritten with badges, feature highlights, and cleaner structure
- **Project metadata** - Added license, authors, keywords, classifiers to pyproject.toml
- **MkDocs documentation** - Full documentation site with:
  - Getting started guides (installation, configuration, quickstart)
  - Command reference (all 9 commands documented)
  - Concept pages (naming convention, soft delete)
  - Material theme with dark/light mode
- **GitHub Actions** - Workflow to deploy docs to GitHub Pages

## Test plan
- [x] mkdocs builds successfully
- [x] All tests pass
- [x] Ruff checks pass

## After merge
Enable GitHub Pages in repository settings (Source: GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)