### PR TITLE
Bump dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 vaultuner = "vaultuner.cli:app"
 
 [dependency-groups]
-dev = ["prek>=0.1.0", "pytest>=8.0.0"]
+dev = ["prek>=0.3.1", "pytest>=9.0.2"]
 docs = ["mkdocs>=1.6.0", "mkdocs-material>=9.5.0"]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -786,8 +786,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "prek", specifier = ">=0.1.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "prek", specifier = ">=0.3.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0" },


### PR DESCRIPTION
## Summary
Updates dev dependencies via `uvx uv-bump`:

- prek 0.1.0 → 0.3.1
- pytest 8.0.0 → 9.0.2

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)