### PR TITLE
chore: ignore Python version in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignoreDeps": [
+    "python"
   ]
 }


### PR DESCRIPTION
## Summary

Ignore Python version updates in Renovate since bitwarden-sdk only provides wheels for Python 3.11-3.12.

Closes #13 permanently (it was configured as immortal).

🤖 Generated with [Claude Code](https://claude.ai/code)