### PR TITLE
fix: trigger PyPI publish from release-please outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -13,17 +11,20 @@ permissions:
 
 jobs:
   release-please:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
 
   publish:
-    if: github.event_name == 'release'
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
## Summary

Use `release_created` output from release-please to conditionally run the publish job, instead of relying on the `release: published` event which wasn't triggering properly.

Pattern copied from mise-completions-sync.

🤖 Generated with [Claude Code](https://claude.ai/code)