### PR TITLE
docs: add --python 3.12 flag to install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ Secrets organized by project and environment. Instantly memorable. Zero cognitiv
 ### Install
 
 ```bash
-uv tool install vaultuner
+uv tool install --python 3.12 vaultuner
 ```
 
 Or run without installing:
 
 ```bash
-uvx vaultuner list
+uvx --python 3.12 vaultuner list
 ```
+
+> **Note:** The `--python 3.12` flag is required because bitwarden-sdk only provides wheels for Python 3.11-3.12.
 
 ### Configure
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,18 +11,21 @@
 The fastest way to install vaultuner is using [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv tool install vaultuner
+uv tool install --python 3.12 vaultuner
 ```
 
 This installs vaultuner as a standalone tool with its own isolated environment.
+
+!!! note "Why `--python 3.12`?"
+    The bitwarden-sdk dependency only provides pre-built wheels for Python 3.11 and 3.12. Without this flag, uv may attempt to use a newer Python version and fail to install.
 
 ## Run Without Installing
 
 You can also run vaultuner directly without installing:
 
 ```bash
-uvx vaultuner list
-uvx vaultuner get myapp/api-key
+uvx --python 3.12 vaultuner list
+uvx --python 3.12 vaultuner get myapp/api-key
 ```
 
 This is useful for one-off commands or trying vaultuner before committing to an install.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,8 @@ Your Bitwarden access token is stored in macOS Keychain, not in plaintext config
 ## Quick Example
 
 ```bash
-# Install
-uv tool install vaultuner
+# Install (--python 3.12 required for bitwarden-sdk compatibility)
+uv tool install --python 3.12 vaultuner
 
 # Configure once
 vaultuner config set access-token <your-token>


### PR DESCRIPTION
## Summary

uv tool install and uvx [ignore `requires-python` from packages](https://docs.astral.sh/uv/concepts/tools/), so users must explicitly specify Python 3.12 for bitwarden-sdk compatibility.

Updated:
- README install section
- docs/getting-started/installation.md
- docs/index.md Quick Example

🤖 Generated with [Claude Code](https://claude.ai/code)