### PR TITLE
feat: add secret generation

### DIFF
--- a/docs/commands/generate.md
+++ b/docs/commands/generate.md
@@ -1,0 +1,46 @@
+# generate
+
+Generate a cryptographically secure random secret value.
+
+## Usage
+
+```bash
+vaultuner generate [OPTIONS]
+```
+
+## Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--length` | `-l` | Length of generated secret | `24` |
+| `--no-lowercase` | | Exclude lowercase letters | Off |
+| `--no-uppercase` | | Exclude uppercase letters | Off |
+| `--no-numbers` | | Exclude digits | Off |
+| `--no-special` | | Exclude special characters (`!@#$%^&*`) | Off |
+| `--allow-ambiguous` | | Allow ambiguous characters (`I`, `O`, `l`, `0`, `1`) | Off |
+
+## Examples
+
+```bash
+# Generate a 24-character secret (default)
+vaultuner generate
+
+# Generate a longer secret
+vaultuner generate --length 64
+
+# Letters and numbers only
+vaultuner generate --no-special
+
+# Alphanumeric lowercase only
+vaultuner generate --no-uppercase --no-special
+```
+
+## Behavior
+
+- Uses Python's `secrets` module for cryptographically secure randomness
+- Ambiguous characters (`I`, `O`, `l`, `0`, `1`) are excluded by default to avoid confusion when copying values manually
+- At least one character set must be enabled
+- Output is printed to stdout with no extra formatting, making it easy to pipe into other commands
+
+!!! tip
+    Use `vaultuner set PATH --generate` to generate and store a secret in one step. See [set](set.md) for details.

--- a/docs/commands/set.md
+++ b/docs/commands/set.md
@@ -13,13 +13,14 @@ vaultuner set PATH VALUE [OPTIONS]
 | Argument | Description |
 |----------|-------------|
 | `PATH` | Secret path: `PROJECT/[ENV/]NAME` |
-| `VALUE` | The secret value |
+| `VALUE` | The secret value (omit when using `--generate`) |
 
 ## Options
 
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--note` | `-n` | Optional note/description |
+| `--generate` | `-g` | Generate a random value instead of providing one |
 
 ## Examples
 
@@ -35,6 +36,9 @@ vaultuner set myapp/api-key "sk-test-abc123" -n "Stripe test key"
 
 # Update an existing secret
 vaultuner set myapp/api-key "new-value"
+
+# Generate and store a random secret
+vaultuner set myapp/prod/api-key --generate
 ```
 
 ## Behavior
@@ -42,3 +46,5 @@ vaultuner set myapp/api-key "new-value"
 - If the secret doesn't exist, it's created
 - If the secret exists, it's updated
 - The secret is automatically associated with a project in Bitwarden
+- When `--generate` is used, a 24-character random value is created and printed to the console
+- Cannot combine `--generate` with an explicit value

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - list: commands/list.md
       - get: commands/get.md
       - set: commands/set.md
+      - generate: commands/generate.md
       - delete: commands/delete.md
       - restore: commands/restore.md
       - export: commands/export.md

--- a/src/vaultuner/cli.py
+++ b/src/vaultuner/cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from vaultuner.client import find_secret_by_key, get_client, get_or_create_project
+from vaultuner.generate import generate_secret
 from vaultuner.config import (
     DEFAULT_PROJECT_NAME,
     delete_keyring_value,
@@ -193,10 +194,23 @@ def get(
 @app.command()
 def set(
     path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME"),
-    value: str = typer.Argument(..., help="Secret value"),
+    value: str | None = typer.Argument(None, help="Secret value"),
     note: str | None = typer.Option(None, "--note", "-n", help="Optional note"),
+    gen: bool = typer.Option(False, "--generate", "-g", help="Generate a random value"),
 ):
     """Create or update a secret."""
+    if gen and value is not None:
+        err_console.print(
+            "[red]Error:[/red] Cannot use --generate with an explicit value"
+        )
+        raise typer.Exit(1)
+    if not gen and value is None:
+        err_console.print("[red]Error:[/red] Provide a value or use --generate")
+        raise typer.Exit(1)
+
+    if gen:
+        value = generate_secret()
+
     settings = get_settings()
     client = get_client()
 
@@ -227,6 +241,9 @@ def set(
             err_console.print("[red]Failed to create secret.[/red]")
             raise typer.Exit(1)
         console.print(f"[green]Created:[/green] {path}")
+
+    if gen:
+        console.print(f"[cyan]Generated value:[/cyan] {value}")
 
 
 @app.command()
@@ -320,6 +337,33 @@ def projects():
         table.add_row(project.name)
 
     console.print(table)
+
+
+@app.command()
+def generate(
+    length: int = typer.Option(24, "--length", "-l", help="Length of generated secret"),
+    no_lowercase: bool = typer.Option(False, "--no-lowercase", help="Exclude lowercase"),
+    no_uppercase: bool = typer.Option(False, "--no-uppercase", help="Exclude uppercase"),
+    no_numbers: bool = typer.Option(False, "--no-numbers", help="Exclude numbers"),
+    no_special: bool = typer.Option(False, "--no-special", help="Exclude special characters"),
+    allow_ambiguous: bool = typer.Option(
+        False, "--allow-ambiguous", help="Allow ambiguous characters (I, O, l, 0, 1)"
+    ),
+):
+    """Generate a random secret value."""
+    try:
+        value = generate_secret(
+            length=length,
+            avoid_ambiguous=not allow_ambiguous,
+            lowercase=not no_lowercase,
+            uppercase=not no_uppercase,
+            numbers=not no_numbers,
+            special=not no_special,
+        )
+    except ValueError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+    print(value)
 
 
 @app.command()

--- a/src/vaultuner/generate.py
+++ b/src/vaultuner/generate.py
@@ -1,0 +1,39 @@
+# ABOUTME: Cryptographically secure secret generation.
+# ABOUTME: Generates random strings with configurable character sets and length.
+
+import secrets
+import string
+
+
+AMBIGUOUS_CHARS = set("IOl01")
+
+
+def generate_secret(
+    length: int = 24,
+    avoid_ambiguous: bool = True,
+    lowercase: bool = True,
+    uppercase: bool = True,
+    numbers: bool = True,
+    special: bool = True,
+) -> str:
+    """Generate a cryptographically secure random string."""
+    if length < 1:
+        raise ValueError("Length must be at least 1")
+
+    alphabet = ""
+    if lowercase:
+        alphabet += string.ascii_lowercase
+    if uppercase:
+        alphabet += string.ascii_uppercase
+    if numbers:
+        alphabet += string.digits
+    if special:
+        alphabet += "!@#$%^&*"
+
+    if not alphabet:
+        raise ValueError("At least one character set must be enabled")
+
+    if avoid_ambiguous:
+        alphabet = "".join(c for c in alphabet if c not in AMBIGUOUS_CHARS)
+
+    return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,77 @@ class TestSetSecret:
         assert "Updated" in result.stdout
 
 
+class TestSetGenerate:
+    @patch("vaultuner.cli.get_or_create_project")
+    @patch("vaultuner.cli.find_secret_by_key")
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_creates_with_generated_value(
+        self, mock_settings, mock_client, mock_find, mock_project
+    ):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+        mock_find.return_value = None
+        mock_project.return_value = "project-id"
+        client = MagicMock()
+        client.secrets().create.return_value = MagicMock(data=MagicMock())
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["set", "myproject/api-key", "--generate"])
+        assert result.exit_code == 0
+        assert "Created" in result.output
+        assert "Generated value:" in result.output
+
+    @patch("vaultuner.cli.get_or_create_project")
+    @patch("vaultuner.cli.find_secret_by_key")
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_generate_prints_value(
+        self, mock_settings, mock_client, mock_find, mock_project
+    ):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+        mock_find.return_value = None
+        mock_project.return_value = "project-id"
+        client = MagicMock()
+        client.secrets().create.return_value = MagicMock(data=MagicMock())
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["set", "myproject/api-key", "--generate"])
+        assert result.exit_code == 0
+        # Verify the value passed to create matches what was printed
+        call_args = client.secrets().create.call_args
+        stored_value = call_args.kwargs.get("value") or call_args[1].get("value")
+        assert stored_value in result.output
+
+    @patch("vaultuner.cli.find_secret_by_key")
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_generate_updates_existing(self, mock_settings, mock_client, mock_find):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+        mock_find.return_value = {"id": "secret-id", "key": "myproject/api-key"}
+        client = MagicMock()
+        client.secrets().update.return_value = MagicMock(data=MagicMock())
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["set", "myproject/api-key", "--generate"])
+        assert result.exit_code == 0
+        assert "Updated" in result.output
+        # Should still print the generated value
+        call_args = client.secrets().update.call_args
+        stored_value = call_args.kwargs.get("value") or call_args[1].get("value")
+        assert stored_value in result.output
+
+    def test_generate_and_value_conflict(self):
+        result = runner.invoke(
+            app, ["set", "myproject/api-key", "my-value", "--generate"]
+        )
+        assert result.exit_code == 1
+        assert "Cannot use --generate with an explicit value" in result.output
+
+    def test_missing_value_and_no_generate(self):
+        result = runner.invoke(app, ["set", "myproject/api-key"])
+        assert result.exit_code != 0
+
+
 class TestDeleteSecret:
     @patch("vaultuner.cli.find_secret_by_key")
     @patch("vaultuner.cli.get_client")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,182 @@
+# ABOUTME: Tests for the secret generation module.
+# ABOUTME: Validates character set selection, length, and ambiguous character handling.
+
+import string
+
+import pytest
+
+from vaultuner.generate import generate_secret
+
+LOWERCASE = set(string.ascii_lowercase)
+UPPERCASE = set(string.ascii_uppercase)
+DIGITS = set(string.digits)
+SPECIAL = set("!@#$%^&*")
+AMBIGUOUS = set("IOl01")
+
+
+class TestGenerateDefaults:
+    def test_default_length(self):
+        result = generate_secret()
+        assert len(result) == 24
+
+    def test_default_contains_lowercase(self):
+        # With 24 chars and all sets enabled, statistically guaranteed
+        # Run multiple times to reduce flakiness
+        chars = set("".join(generate_secret() for _ in range(10)))
+        assert chars & LOWERCASE
+
+    def test_default_contains_uppercase(self):
+        chars = set("".join(generate_secret() for _ in range(10)))
+        assert chars & UPPERCASE
+
+    def test_default_contains_digits(self):
+        chars = set("".join(generate_secret() for _ in range(10)))
+        assert chars & DIGITS
+
+    def test_default_contains_special(self):
+        chars = set("".join(generate_secret() for _ in range(10)))
+        assert chars & SPECIAL
+
+    def test_default_avoids_ambiguous(self):
+        # Generate many secrets, none should contain ambiguous chars
+        for _ in range(50):
+            result = generate_secret()
+            assert not (set(result) & AMBIGUOUS), f"Found ambiguous char in: {result}"
+
+
+class TestGenerateLength:
+    def test_custom_length(self):
+        assert len(generate_secret(length=64)) == 64
+
+    def test_minimum_length(self):
+        assert len(generate_secret(length=1)) == 1
+
+    def test_zero_length_raises(self):
+        with pytest.raises(ValueError, match="at least 1"):
+            generate_secret(length=0)
+
+    def test_negative_length_raises(self):
+        with pytest.raises(ValueError, match="at least 1"):
+            generate_secret(length=-5)
+
+
+class TestGenerateCharacterSets:
+    def test_lowercase_only(self):
+        result = generate_secret(
+            length=100, uppercase=False, numbers=False, special=False
+        )
+        assert set(result) <= LOWERCASE
+
+    def test_uppercase_only(self):
+        result = generate_secret(
+            length=100, lowercase=False, numbers=False, special=False
+        )
+        # With avoid_ambiguous=True, I and O are excluded
+        assert set(result) <= (UPPERCASE - AMBIGUOUS)
+
+    def test_numbers_only(self):
+        result = generate_secret(
+            length=100, lowercase=False, uppercase=False, special=False
+        )
+        assert set(result) <= (DIGITS - AMBIGUOUS)
+
+    def test_special_only(self):
+        result = generate_secret(
+            length=100,
+            lowercase=False,
+            uppercase=False,
+            numbers=False,
+        )
+        assert set(result) <= SPECIAL
+
+    def test_no_character_sets_raises(self):
+        with pytest.raises(ValueError, match="At least one"):
+            generate_secret(
+                lowercase=False, uppercase=False, numbers=False, special=False
+            )
+
+
+class TestGenerateAmbiguous:
+    def test_allow_ambiguous(self):
+        # With ambiguous allowed and enough length, should eventually include them
+        chars = set(
+            "".join(
+                generate_secret(length=100, avoid_ambiguous=False) for _ in range(20)
+            )
+        )
+        assert chars & AMBIGUOUS
+
+    def test_avoid_ambiguous_excludes_from_all_sets(self):
+        for _ in range(50):
+            result = generate_secret(length=100, avoid_ambiguous=True)
+            assert not (set(result) & AMBIGUOUS)
+
+
+class TestGenerateCLI:
+    """Tests for the generate CLI command."""
+
+    from typer.testing import CliRunner
+
+    runner = CliRunner()
+
+    def test_generate_prints_secret(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate"])
+        assert result.exit_code == 0
+        # Output should be a single line with the generated secret
+        lines = result.stdout.strip().split("\n")
+        assert len(lines) == 1
+        assert len(lines[0]) == 24
+
+    def test_generate_custom_length(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--length", "64"])
+        assert result.exit_code == 0
+        assert len(result.stdout.strip()) == 64
+
+    def test_generate_no_special(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--no-special", "-l", "100"])
+        assert result.exit_code == 0
+        assert not (set(result.stdout.strip()) & SPECIAL)
+
+    def test_generate_no_uppercase(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--no-uppercase", "-l", "100"])
+        assert result.exit_code == 0
+        assert not (set(result.stdout.strip()) & UPPERCASE)
+
+    def test_generate_no_lowercase(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--no-lowercase", "-l", "100"])
+        assert result.exit_code == 0
+        assert not (set(result.stdout.strip()) & LOWERCASE)
+
+    def test_generate_no_numbers(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--no-numbers", "-l", "100"])
+        assert result.exit_code == 0
+        assert not (set(result.stdout.strip()) & DIGITS)
+
+    def test_generate_allow_ambiguous(self):
+        from vaultuner.cli import app
+
+        chars = set()
+        for _ in range(20):
+            result = self.runner.invoke(
+                app, ["generate", "--allow-ambiguous", "-l", "100"]
+            )
+            chars.update(result.stdout.strip())
+        assert chars & AMBIGUOUS
+
+    def test_generate_invalid_length(self):
+        from vaultuner.cli import app
+
+        result = self.runner.invoke(app, ["generate", "--length", "0"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- Adds `vaultuner generate` command for creating cryptographically secure random secrets with configurable length, character sets, and ambiguous character filtering
- Adds `--generate` / `-g` flag to `vaultuner set` to generate and store a secret in one step (prints the generated value)
- Uses Python's `secrets` module (no new dependencies); can swap to Bitwarden SDK generator when [bitwarden/sdk-sm#1344](https://github.com/bitwarden/sdk-sm/pull/1344) is released

## Test plan

- [x] 25 tests for generation logic (character sets, length, ambiguous chars, CLI flags)
- [x] 5 tests for `set --generate` (create, update, print value, conflict with explicit value, missing value)
- [x] All 143 tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)