### PR TITLE
fix: handle inaccessible keychain gracefully over SSH

### DIFF
--- a/src/vaultuner/cli.py
+++ b/src/vaultuner/cli.py
@@ -16,6 +16,7 @@ from vaultuner.config import (
     delete_keyring_value,
     get_keyring_value,
     get_settings,
+    is_keyring_accessible,
     set_keyring_value,
 )
 from vaultuner.models import (
@@ -78,6 +79,15 @@ def config_show():
     table = Table(show_header=True, header_style="bold")
     table.add_column("Setting", style="cyan")
     table.add_column("Status")
+
+    keyring_available = is_keyring_accessible()
+
+    if not keyring_available:
+        console.print(
+            "[yellow]Warning:[/yellow] Keychain is not accessible. "
+            "Run this command from a regular (non-remote) shell to manage keychain credentials.\n"
+            "You can still use environment variables BWS_ACCESS_TOKEN and BWS_ORGANIZATION_ID.\n"
+        )
 
     access_token = get_keyring_value(KEYRING_MAP["access-token"])
     org_id = get_keyring_value(KEYRING_MAP["organization-id"])

--- a/src/vaultuner/config.py
+++ b/src/vaultuner/config.py
@@ -21,10 +21,13 @@ def _require_darwin() -> None:
 
 
 def get_keyring_value(key: str) -> str | None:
-    """Get a value from the system keychain. Returns None on non-darwin."""
+    """Get a value from the system keychain. Returns None on non-darwin or if inaccessible."""
     if sys.platform != "darwin":
         return None
-    return keyring.get_password(SERVICE_NAME, key)
+    try:
+        return keyring.get_password(SERVICE_NAME, key)
+    except keyring.errors.KeyringError:
+        return None
 
 
 def set_keyring_value(key: str, value: str) -> None:

--- a/src/vaultuner/config.py
+++ b/src/vaultuner/config.py
@@ -20,6 +20,17 @@ def _require_darwin() -> None:
         )
 
 
+def is_keyring_accessible() -> bool:
+    """Check whether the system keychain can be reached."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        keyring.get_password(SERVICE_NAME, "__probe__")
+        return True
+    except keyring.errors.KeyringError:
+        return False
+
+
 def get_keyring_value(key: str) -> str | None:
     """Get a value from the system keychain. Returns None on non-darwin or if inaccessible."""
     if sys.platform != "darwin":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,16 @@ class TestConfigShow:
         assert "some-org-uuid-12345" not in result.stdout
         assert "configured" in result.stdout
 
+    @patch("vaultuner.cli.is_keyring_accessible")
+    @patch("vaultuner.cli.get_keyring_value")
+    def test_warns_when_keyring_inaccessible(self, mock_get, mock_accessible):
+        mock_accessible.return_value = False
+        mock_get.return_value = None
+        result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "keychain is not accessible" in result.stdout.lower()
+        assert "regular" in result.stdout.lower()
+
 
 class TestConfigDelete:
     @patch("vaultuner.cli.delete_keyring_value")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,14 @@ class TestGetKeyringValue:
         result = get_keyring_value("missing_key")
         assert result is None
 
+    @patch("vaultuner.config.keyring.get_password")
+    def test_returns_none_when_keyring_inaccessible(self, mock_get):
+        import keyring.errors
+
+        mock_get.side_effect = keyring.errors.KeyringError("(-25308, 'Unknown Error')")
+        result = get_keyring_value("test_key")
+        assert result is None
+
 
 class TestSetKeyringValue:
     @patch("vaultuner.config.keyring.set_password")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from vaultuner.config import (
     SERVICE_NAME,
     delete_keyring_value,
     get_keyring_value,
+    is_keyring_accessible,
     set_keyring_value,
 )
 
@@ -55,6 +56,24 @@ class TestDeleteKeyringValue:
 
         mock_delete.side_effect = keyring.errors.PasswordDeleteError()
         delete_keyring_value("missing_key")
+
+
+class TestIsKeyringAccessible:
+    @patch("vaultuner.config.keyring.get_password")
+    def test_returns_true_when_accessible(self, mock_get):
+        mock_get.return_value = None
+        assert is_keyring_accessible() is True
+
+    @patch("vaultuner.config.keyring.get_password")
+    def test_returns_false_when_keyring_error(self, mock_get):
+        import keyring.errors
+
+        mock_get.side_effect = keyring.errors.KeyringError("(-25308, 'Unknown Error')")
+        assert is_keyring_accessible() is False
+
+    @patch("vaultuner.config.sys.platform", "linux")
+    def test_returns_false_on_non_darwin(self):
+        assert is_keyring_accessible() is False
 
 
 class TestPlatformCheck:


### PR DESCRIPTION
## Summary
- Catch `KeyringError` in `get_keyring_value` so the tool falls back to env vars instead of crashing when the macOS keychain is inaccessible (e.g. over SSH)
- Add `is_keyring_accessible()` check and display a warning in `config show` when the keychain can't be reached, pointing users to env vars
- Add tests for both behaviors

## Test plan
- [x] `get_keyring_value` returns `None` when keychain throws `KeyringError`
- [x] `is_keyring_accessible` returns `False` when keychain is unreachable
- [x] `config show` prints warning when keychain is inaccessible
- [x] All 148 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)