### PR TITLE
fix: remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: MacOS",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/uv.lock
+++ b/uv.lock
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "vaultuner"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "bitwarden-sdk" },


### PR DESCRIPTION
## Summary
- Removed the deprecated `License :: OSI Approved :: MIT License` classifier from `pyproject.toml`
- The license is already declared via the PEP 639 `license` field, making the classifier redundant and triggering warnings on `uv add` and other operations

## Test plan
- [x] `uv sync` runs without license classifier warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)