### PR TITLE
feat: support @org/repo scoped secret paths

### DIFF
--- a/src/vaultuner/cli.py
+++ b/src/vaultuner/cli.py
@@ -1,6 +1,7 @@
 # ABOUTME: Typer CLI for Bitwarden Secrets Manager.
 # ABOUTME: Commands for listing, getting, setting, and deleting secrets.
 
+import builtins
 from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated, Literal
@@ -39,7 +40,7 @@ def version_callback(value: bool) -> None:
 
 
 app = typer.Typer(
-    help=f"Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET naming. (v{__version__})",
+    help=f"Bitwarden Secrets Manager CLI with PROJECT/[ENV/]SECRET and @ORG/REPO/[ENV/]SECRET naming. (v{__version__})",
     no_args_is_help=True,
 )
 config_app = typer.Typer(help="Manage vaultuner credentials stored in system keychain.")
@@ -174,7 +175,7 @@ def list_secrets(
 
 @app.command()
 def get(
-    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME"),
+    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME or @ORG/REPO/[ENV/]NAME"),
     value_only: bool = typer.Option(
         False, "--value", "-v", help="Print only the value"
     ),
@@ -209,7 +210,7 @@ def get(
 
 @app.command()
 def set(
-    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME"),
+    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME or @ORG/REPO/[ENV/]NAME"),
     value: str | None = typer.Argument(None, help="Secret value"),
     note: str | None = typer.Option(None, "--note", "-n", help="Optional note"),
     description: str | None = typer.Option(
@@ -296,7 +297,7 @@ def set(
 
 @app.command()
 def delete(
-    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME"),
+    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME or @ORG/REPO/[ENV/]NAME"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
     permanent: bool = typer.Option(False, "--permanent", help="Permanently delete"),
 ):
@@ -340,7 +341,7 @@ def delete(
 
 @app.command()
 def restore(
-    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME"),
+    path: str = typer.Argument(..., help="Secret path: PROJECT/[ENV/]NAME or @ORG/REPO/[ENV/]NAME"),
 ):
     """Restore a soft-deleted secret."""
     settings = get_settings()
@@ -370,19 +371,33 @@ def restore(
 
 @app.command()
 def projects():
-    """List all projects."""
+    """List all projects (derived from secret names)."""
     settings = get_settings()
     client = get_client()
-    response = client.projects().list(settings.organization_id)
+    response = client.secrets().list(settings.organization_id)
     if not response.data or not response.data.data:
+        console.print("[dim]No projects found.[/dim]")
+        return
+
+    project_names: builtins.set[str] = builtins.set()
+    for secret in response.data.data:
+        if is_deleted(secret.key):
+            continue
+        try:
+            path = SecretPath.parse(secret.key)
+        except ValueError:
+            continue
+        project_names.add(path.project)
+
+    if not project_names:
         console.print("[dim]No projects found.[/dim]")
         return
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("Project", style="cyan")
 
-    for project in response.data.data:
-        table.add_row(project.name)
+    for name in sorted(project_names):
+        table.add_row(name)
 
     console.print(table)
 

--- a/src/vaultuner/models.py
+++ b/src/vaultuner/models.py
@@ -1,5 +1,5 @@
 # ABOUTME: Data models for vaultuner.
-# ABOUTME: SecretPath, SecretMetadata, and note frontmatter parsing.
+# ABOUTME: SecretPath (plain and @org/repo scoped), SecretMetadata, and note frontmatter parsing.
 
 from pydantic import BaseModel, ConfigDict
 
@@ -30,7 +30,7 @@ class SecretPath(BaseModel):
 
     @classmethod
     def parse(cls, path: str) -> "SecretPath":
-        """Parse a path like 'project/env/name' or 'project/name'."""
+        """Parse a path like 'project/env/name' or '@org/repo/env/name'."""
         parts = path.split("/")
 
         if any(not part for part in parts):
@@ -38,14 +38,31 @@ class SecretPath(BaseModel):
                 f"Invalid path format: {path}. Path segments cannot be empty."
             )
 
-        if len(parts) == 3:
-            return cls(project=parts[0], env=parts[1], name=parts[2])
-        elif len(parts) == 2:
-            return cls(project=parts[0], name=parts[1])
-        else:
+        is_scoped = parts[0].startswith("@")
+
+        if is_scoped and len(parts[0]) == 1:
             raise ValueError(
-                f"Invalid path format: {path}. Expected PROJECT/[ENV/]NAME"
+                f"Invalid path format: {path}. Path segments cannot be empty."
             )
+
+        if is_scoped:
+            if len(parts) == 4:
+                return cls(project=f"{parts[0]}/{parts[1]}", env=parts[2], name=parts[3])
+            elif len(parts) == 3:
+                return cls(project=f"{parts[0]}/{parts[1]}", name=parts[2])
+            else:
+                raise ValueError(
+                    f"Invalid path format: {path}. Expected @ORG/REPO/[ENV/]NAME"
+                )
+        else:
+            if len(parts) == 3:
+                return cls(project=parts[0], env=parts[1], name=parts[2])
+            elif len(parts) == 2:
+                return cls(project=parts[0], name=parts[1])
+            else:
+                raise ValueError(
+                    f"Invalid path format: {path}. Expected PROJECT/[ENV/]NAME"
+                )
 
     def to_key(self) -> str:
         """Convert to Bitwarden secret key format."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,27 @@ class TestListSecrets:
 
     @patch("vaultuner.cli.get_client")
     @patch("vaultuner.cli.get_settings")
+    def test_filters_by_scoped_project(self, mock_settings, mock_client):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+
+        secrets = [
+            MagicMock(key="@dpoblador/vaultuner/prod/api-key"),
+            MagicMock(key="@dpoblador/vaultuner/dev/db-pass"),
+            MagicMock(key="myproject/api-key"),
+        ]
+        client = MagicMock()
+        client.secrets().list.return_value = MagicMock(
+            data=MagicMock(data=secrets)
+        )
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["list", "-p", "@dpoblador/vaultuner"])
+        assert result.exit_code == 0
+        assert "@dpoblador/vaultuner" in result.stdout
+        assert "myproject" not in result.stdout
+
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
     def test_empty_response(self, mock_settings, mock_client):
         mock_settings.return_value = MagicMock(organization_id="org-123")
         client = MagicMock()
@@ -534,24 +555,85 @@ class TestRestoreSecret:
 class TestProjects:
     @patch("vaultuner.cli.get_client")
     @patch("vaultuner.cli.get_settings")
-    def test_lists_projects(self, mock_settings, mock_client):
+    def test_lists_semantic_projects(self, mock_settings, mock_client):
         mock_settings.return_value = MagicMock(organization_id="org-123")
-        project = MagicMock()
-        project.name = "myproject"
+
+        secrets = [
+            MagicMock(key="myproject/api-key"),
+            MagicMock(key="myproject/prod/db-pass"),
+            MagicMock(key="other/secret"),
+        ]
         client = MagicMock()
-        client.projects().list.return_value = MagicMock(data=MagicMock(data=[project]))
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=secrets))
         mock_client.return_value = client
 
         result = runner.invoke(app, ["projects"])
         assert result.exit_code == 0
         assert "myproject" in result.output
+        assert "other" in result.output
+
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_lists_scoped_projects(self, mock_settings, mock_client):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+
+        secrets = [
+            MagicMock(key="@dpoblador/vaultuner/prod/api-key"),
+            MagicMock(key="@dpoblador/vaultuner/dev/api-key"),
+            MagicMock(key="myproject/api-key"),
+        ]
+        client = MagicMock()
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=secrets))
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["projects"])
+        assert result.exit_code == 0
+        assert "@dpoblador/vaultuner" in result.output
+        assert "myproject" in result.output
+
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_deduplicates_projects(self, mock_settings, mock_client):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+
+        secrets = [
+            MagicMock(key="myproject/api-key"),
+            MagicMock(key="myproject/prod/db-pass"),
+            MagicMock(key="myproject/dev/db-pass"),
+        ]
+        client = MagicMock()
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=secrets))
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["projects"])
+        assert result.exit_code == 0
+        # Should appear once, not three times
+        assert result.output.count("myproject") == 1
+
+    @patch("vaultuner.cli.get_client")
+    @patch("vaultuner.cli.get_settings")
+    def test_ignores_deleted_secrets(self, mock_settings, mock_client):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+
+        secrets = [
+            MagicMock(key="myproject/api-key"),
+            MagicMock(key="_deleted_/oldproject/secret"),
+        ]
+        client = MagicMock()
+        client.secrets().list.return_value = MagicMock(data=MagicMock(data=secrets))
+        mock_client.return_value = client
+
+        result = runner.invoke(app, ["projects"])
+        assert result.exit_code == 0
+        assert "myproject" in result.output
+        assert "oldproject" not in result.output
 
     @patch("vaultuner.cli.get_client")
     @patch("vaultuner.cli.get_settings")
     def test_empty(self, mock_settings, mock_client):
         mock_settings.return_value = MagicMock(organization_id="org-123")
         client = MagicMock()
-        client.projects().list.return_value = MagicMock(data=None)
+        client.secrets().list.return_value = MagicMock(data=None)
         mock_client.return_value = client
 
         result = runner.invoke(app, ["projects"])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -239,3 +239,27 @@ class TestExportSecrets:
         content = output.read_text()
         # Quotes should be escaped so the .env file is valid
         assert r'QUOTED_VAL="value with \"quotes\" inside"' in content
+
+    @patch("vaultuner.export.get_client")
+    @patch("vaultuner.export.get_settings")
+    def test_filters_by_scoped_project(self, mock_settings, mock_client, tmp_path):
+        mock_settings.return_value = MagicMock(organization_id="org-123")
+
+        secret1 = MagicMock(id="1", key="@dpoblador/vaultuner/prod/api-key")
+        secret2 = MagicMock(id="2", key="myproject/api-key")
+
+        client = MagicMock()
+        client.secrets().list.return_value = MagicMock(
+            data=MagicMock(data=[secret1, secret2])
+        )
+        client.secrets().get.return_value = MagicMock(
+            data=MagicMock(value="scoped-secret")
+        )
+        mock_client.return_value = client
+
+        output = tmp_path / ".env"
+        added, skipped = export_secrets("@dpoblador/vaultuner", output, env="prod")
+
+        assert added == 1
+        assert skipped == 0
+        assert 'API_KEY="scoped-secret"' in output.read_text()

--- a/tests/test_import_env.py
+++ b/tests/test_import_env.py
@@ -98,3 +98,15 @@ class TestBuildSecretPath:
 
     def test_with_empty_env(self):
         assert build_secret_path("proj", "", "key") == "proj/key"
+
+    def test_scoped_project_with_env(self):
+        assert (
+            build_secret_path("@dpoblador/vaultuner", "prod", "api-key")
+            == "@dpoblador/vaultuner/prod/api-key"
+        )
+
+    def test_scoped_project_without_env(self):
+        assert (
+            build_secret_path("@dpoblador/vaultuner", None, "api-key")
+            == "@dpoblador/vaultuner/api-key"
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,6 +54,60 @@ class TestSecretPathParse:
         assert path.name == "api-key_v2"
 
 
+class TestSecretPathParseScoped:
+    """Tests for @org/repo scoped paths."""
+
+    def test_parse_at_org_repo_name(self):
+        path = SecretPath.parse("@dpoblador/vaultuner/api-key")
+        assert path.project == "@dpoblador/vaultuner"
+        assert path.env is None
+        assert path.name == "api-key"
+
+    def test_parse_at_org_repo_env_name(self):
+        path = SecretPath.parse("@dpoblador/vaultuner/prod/api-key")
+        assert path.project == "@dpoblador/vaultuner"
+        assert path.env == "prod"
+        assert path.name == "api-key"
+
+    def test_parse_at_org_repo_only_raises(self):
+        with pytest.raises(ValueError, match="Invalid path format"):
+            SecretPath.parse("@dpoblador/vaultuner")
+
+    def test_parse_at_org_only_raises(self):
+        with pytest.raises(ValueError, match="Invalid path format"):
+            SecretPath.parse("@dpoblador")
+
+    def test_parse_at_five_parts_raises(self):
+        with pytest.raises(ValueError, match="Invalid path format"):
+            SecretPath.parse("@dpoblador/vaultuner/prod/api-key/extra")
+
+    def test_parse_at_empty_org_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            SecretPath.parse("@/repo/name")
+
+    def test_parse_at_empty_repo_raises(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            SecretPath.parse("@org//name")
+
+    def test_to_key_roundtrip_without_env(self):
+        path = SecretPath.parse("@dpoblador/vaultuner/api-key")
+        assert path.to_key() == "@dpoblador/vaultuner/api-key"
+
+    def test_to_key_roundtrip_with_env(self):
+        path = SecretPath.parse("@dpoblador/vaultuner/prod/api-key")
+        assert path.to_key() == "@dpoblador/vaultuner/prod/api-key"
+
+    def test_str_delegates_to_to_key(self):
+        path = SecretPath(project="@dpoblador/vaultuner", env="staging", name="key")
+        assert str(path) == "@dpoblador/vaultuner/staging/key"
+
+    def test_special_chars_in_org_repo(self):
+        path = SecretPath.parse("@my-org/my_repo.v2/prod/secret")
+        assert path.project == "@my-org/my_repo.v2"
+        assert path.env == "prod"
+        assert path.name == "secret"
+
+
 class TestSecretPathToKey:
     def test_to_key_with_env(self):
         path = SecretPath(project="proj", env="prod", name="secret")


### PR DESCRIPTION
## Summary
- Add `@org/repo` as a forge-marker prefix for GitHub repo-scoped secrets (e.g., `@dpoblador/vaultuner/prod/api-key`), extensible to other forges in the future
- Redesign `projects` command to list semantic project names derived from secret keys instead of Bitwarden API projects
- Full backwards compatibility: existing `project/[env/]name` paths are unchanged

## Test plan
- [x] 11 new tests for `@`-prefixed `SecretPath` parsing (valid paths, error cases, roundtrips)
- [x] 5 new tests for redesigned `projects` command (semantic listing, deduplication, deleted filtering, scoped projects)
- [x] Confirmation tests for `list`, `export`, and `import` with scoped projects
- [x] All 193 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)