### PR TITLE
ci: validate PR titles as conventional commits

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,35 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            style
+            test
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject must not be empty.
+          validateSingleCommit: false
+          ignoreLabels: |
+            skip-changelog


### PR DESCRIPTION
Closes #56

## Summary

Adds `amannn/action-semantic-pull-request@v6` to validate PR titles as conventional commits before merge. Matches the workflow already shipping in `alltuner/vibetuner`.

## Why

`alltuner/mise-completions-sync` PR #63 squash-merged with a non-conventional title; release-please failed to parse the squash subject (`unexpected token \` \` at 1:6`) and skipped the only commit since the prior release, so no release PR was opened. Other parseable commits in the same window normally mask this — it surfaces only when a non-conventional PR is the sole change since the last release.

This repo has the same exposure (release-please via `.github/workflows/release.yml`, squash-merge with `COMMIT_OR_PR_TITLE`, no PR title check). See alltuner/vaultuner#56.

## Test plan

- [ ] Workflow file is syntactically valid (loads on the next PR open)
- [ ] Opening a PR with a non-conventional title posts a failed status check
- [ ] Opening a PR with `feat: ...` / `fix: ...` etc. passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)